### PR TITLE
Remove regular expression inline flags

### DIFF
--- a/ib/opt/message.py
+++ b/ib/opt/message.py
@@ -41,14 +41,14 @@ class SignatureAccumulator(NodeVisitor):
 class EClientSocketAccumulator(SignatureAccumulator):
     def getSignatures(self):
         for name, args in self.signatures:
-            if match('(?i)req|cancel|place', name):
+            if match('req|cancel|place', name.lower()):
                 yield (name, args)
 
 
 class EWrapperAccumulator(SignatureAccumulator):
     def getSignatures(self):
         for name, args in self.signatures:
-            if match('(?!((?i)error.*))', name):
+            if not name.lower().startswith('error'):
                 yield (name, args)
 
 


### PR DESCRIPTION
Python 3.11 wants "?i" to be at the front, but frankly, doing a lowercase conversion before matching is much easier to read. Also one regex is equivalent to .startswith, so let's use that.